### PR TITLE
check for body param

### DIFF
--- a/lib/request-browser.js
+++ b/lib/request-browser.js
@@ -287,7 +287,7 @@ class RequestOptions {
     return {
       method: this.method,
       headers: this.getHeaders(),
-      body: this.body.buffer,
+      body: this.body ? this.body.buffer : null,
       mode: 'cors',
       credentials: 'include',
       cache: 'no-cache',


### PR DESCRIPTION
Was causing an error when using bclient in the browser for GET requests since there's no body.