### PR TITLE
headers: support custom headers

### DIFF
--- a/lib/request-browser.js
+++ b/lib/request-browser.js
@@ -41,6 +41,7 @@ class RequestOptions {
     this.timeout = 5000;
     this.buffer = buffer || false;
     this.headers = null;
+    this.customHeaders = null;
 
     if (options)
       this.fromOptions(options);
@@ -161,6 +162,11 @@ class RequestOptions {
       this.headers = options.headers;
     }
 
+    if (options.customHeaders != null) {
+      assert(typeof options.customHeaders === 'object');
+      this.customHeaders = options.customHeaders;
+    }
+
     if (options.lookup != null) {
       assert(typeof options.lookup === 'function');
       this.lookup = options.lookup;
@@ -261,6 +267,12 @@ class RequestOptions {
       const auth = `${this.username}:${this.password}`;
       const data = Buffer.from(auth, 'utf8');
       headers.append('Authorization', `Basic ${data.toString('base64')}`);
+    }
+
+    if (this.customHeaders) {
+      for (const name in this.customHeaders) {
+        headers.append(name, this.customHeaders[name]);
+      }
     }
 
     return headers;

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,6 +50,7 @@ class RequestOptions {
     this.timeout = 5000;
     this.buffer = buffer || false;
     this.headers = null;
+    this.customHeaders = null;
 
     // Hack
     ensureRequires();
@@ -180,6 +181,11 @@ class RequestOptions {
       this.headers = options.headers;
     }
 
+    if (options.customHeaders != null) {
+      assert(typeof options.customHeaders === 'object');
+      this.customHeaders = options.customHeaders;
+    }
+
     if (options.lookup != null) {
       assert(typeof options.lookup === 'function');
       this.lookup = options.lookup;
@@ -289,6 +295,9 @@ class RequestOptions {
       const data = Buffer.from(auth, 'utf8');
       headers['Authorization'] = `Basic ${data.toString('base64')}`;
     }
+
+    if (this.customHeaders)
+      Object.assign(headers, this.customHeaders);
 
     return headers;
   }


### PR DESCRIPTION
Allow for passing in custom headers. Useful for API clients that require special auth headers, and more.

(Related bcurl PR: https://github.com/bcoin-org/bcurl/pull/5)

Note: Did not actually test `request-browser` version, currently only using node version. It *should* work.