### PR TITLE
mime: allow text/json

### DIFF
--- a/lib/mime.js
+++ b/lib/mime.js
@@ -75,6 +75,7 @@ const extensions = {
   'text/javascript': 'js',
   'application/javascript': 'js',
   'text/x-json': 'json',
+  'text/json': 'json',
   'application/json': 'json',
   'text/plain': 'txt',
   'text/cache-manifest': 'manifest',


### PR DESCRIPTION
Addresses #7 

Some API's out there actually return `content-type: text/json` but the message won't get through this content check, affects `bcurl`.