### PR TITLE
Manually create array buffer in browser/Electron

### DIFF
--- a/lib/request-browser.js
+++ b/lib/request-browser.js
@@ -303,6 +303,15 @@ class RequestOptions {
       referrer: 'no-referrer'
     };
   }
+  
+  bufToArrayBuf(buf) {
+    const ab = new ArrayBuffer(buf.length);
+    const view = new Uint8Array(ab);
+    for (let i = 0; i < buf.length; ++i) {
+      view[i] = buf[i];
+    }
+    return ab;
+  }
 }
 
 class Response {
@@ -417,15 +426,6 @@ async function request(options) {
     options = { url: options };
 
   return _request(options, true);
-}
-
-function bufToArrayBuf(buf) {
-  const ab = new ArrayBuffer(buf.length);
-  const view = new Uint8Array(ab);
-  for (let i = 0; i < buf.length; ++i) {
-    view[i] = buf[i];
-  }
-  return ab;
 }
 
 request.stream = function stream(options) {

--- a/lib/request-browser.js
+++ b/lib/request-browser.js
@@ -295,7 +295,7 @@ class RequestOptions {
     return {
       method: this.method,
       headers: this.getHeaders(),
-      body: this.body ? this.body.buffer : null,
+      body: this.body ? this.bufToArrayBuf(this.body) : null,
       mode: 'cors',
       credentials: 'include',
       cache: 'no-cache',
@@ -417,6 +417,15 @@ async function request(options) {
     options = { url: options };
 
   return _request(options, true);
+}
+
+function bufToArrayBuf(buf) {
+  const ab = new ArrayBuffer(buf.length);
+  const view = new Uint8Array(ab);
+  for (let i = 0; i < buf.length; ++i) {
+    view[i] = buf[i];
+  }
+  return ab;
 }
 
 request.stream = function stream(options) {


### PR DESCRIPTION
Hi there,

When running this code in an Electron context, the call to `this.body.buffer` returns all data inside the internal buffer pool. This causes the entirety of the buffer pool to be sent to the server, thus breaking requests and causing potential security risks if sensitive data is inside the buffer pool. To reproduce, you can open any Electron app's web inspector and execute the following from the console:

```
const a = Buffer.from('foo', 'utf-8');
a.buffer
```

You'll see that an 8192-length array buffer with various contents is returned.

This PR fixes the issue by manually creating an `ArrayBuffer` via a `Uint8Array` view.