### PR TITLE
request: expose ca option

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -50,6 +50,7 @@ class RequestOptions {
     this.timeout = 5000;
     this.buffer = buffer || false;
     this.headers = Object.create(null);
+    this.ca = null;
 
     // Hack
     ensureRequires();
@@ -183,6 +184,11 @@ class RequestOptions {
     if (options.lookup != null) {
       assert(typeof options.lookup === 'function');
       this.lookup = options.lookup;
+    }
+
+    if (options.ca != null) {
+      assert(Buffer.isBuffer(options.ca));
+      this.ca = options.ca;
     }
 
     return this;
@@ -332,7 +338,8 @@ class RequestOptions {
       headers: this.getHeaders(),
       agent: this.pool ? null : false,
       lookup: this.lookup || undefined,
-      rejectUnauthorized: this.strictSSL
+      rejectUnauthorized: this.strictSSL,
+      ca: this.ca
     };
   }
 }


### PR DESCRIPTION
From https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options

> ca <string> | <string[]> | <Buffer> | <Buffer[]> Optionally override the trusted CA certificates. Default is to trust the well-known CAs curated by Mozilla. Mozilla's CAs are completely replaced when CAs are explicitly specified using this option. The value can be a string or Buffer, or an Array of strings and/or Buffers. Any string or Buffer can contain multiple PEM CAs concatenated together. The peer's certificate must be chainable to a CA trusted by the server for the connection to be authenticated. When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified as a trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain to one of the default CAs, use the ca option to provide a CA certificate that the peer's certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided. For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE". See also tls.rootCertificates.

and https://nodejs.org/api/https.html#https_https_request_options_callback

> The following additional options from tls.connect() are also accepted: ca, cert, ciphers, clientCertEngine, crl, dhparam, ecdhCurve, honorCipherOrder, key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext, highWaterMark.

Using this option, an application can create a secure SSL connection with a server that does not have centralized-certificate-authority-signed certificate.

I am planning on writing a guide including the necessary openssl commands to generate a chain of certificates for this use case. Along with https://github.com/bcoin-org/bcurl/pull/19 in `bcurl`, a package (signed by its developer and verified by its user) can include an entire CA certificate, and add it at run time to the https module actually making the secure request:

```js
'use strict';

const fs = require('fs');
const {Client} = require('bcurl');

const ca = fs.readFileSync(
  '/Users/matthewzipkin/Desktop/work/cert-auth-test/config/CA/ca.crt'
);

const client = new Client({
  url: 'https://127.0.0.1',
  ca
});

(async() => {
  const r = await client.get('/test');
  console.log(r);
})();

```



